### PR TITLE
Post notification when a `DataResponse` is received from a `DataRequest`

### DIFF
--- a/HTTPRequest.xcodeproj/project.pbxproj
+++ b/HTTPRequest.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 		B89245E925E7DC8D0026C4D9 /* URL+ProjectDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89245E825E7DC8D0026C4D9 /* URL+ProjectDirectory.swift */; };
 		B89245FB25E7E24A0026C4D9 /* FileURLError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89245FA25E7E24A0026C4D9 /* FileURLError.swift */; };
 		B892460525E7F36C0026C4D9 /* ModelFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = B892460425E7F36C0026C4D9 /* ModelFile.swift */; };
+		B8C38DB227902EFB008D8E66 /* Notification+DataRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C38DB127902EFB008D8E66 /* Notification+DataRequest.swift */; };
+		B8C38DB427902FA8008D8E66 /* NotificationCenter+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C38DB327902FA8008D8E66 /* NotificationCenter+Extensions.swift */; };
 		B8E023642767540E003FBC9D /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E023632767540E003FBC9D /* Logger.swift */; };
 		B8E0236E27675812003FBC9D /* DataRequestSuccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E02366276757B0003FBC9D /* DataRequestSuccess.swift */; };
 		B8E0236F27675817003FBC9D /* HTTPRequestable+Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E02368276757BE003FBC9D /* HTTPRequestable+Request.swift */; };
@@ -175,6 +177,8 @@
 		B89245E825E7DC8D0026C4D9 /* URL+ProjectDirectory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+ProjectDirectory.swift"; sourceTree = "<group>"; };
 		B89245FA25E7E24A0026C4D9 /* FileURLError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileURLError.swift; sourceTree = "<group>"; };
 		B892460425E7F36C0026C4D9 /* ModelFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelFile.swift; sourceTree = "<group>"; };
+		B8C38DB127902EFB008D8E66 /* Notification+DataRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+DataRequest.swift"; sourceTree = "<group>"; };
+		B8C38DB327902FA8008D8E66 /* NotificationCenter+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationCenter+Extensions.swift"; sourceTree = "<group>"; };
 		B8E023632767540E003FBC9D /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		B8E02366276757B0003FBC9D /* DataRequestSuccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataRequestSuccess.swift; sourceTree = "<group>"; };
 		B8E02368276757BE003FBC9D /* HTTPRequestable+Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HTTPRequestable+Request.swift"; sourceTree = "<group>"; };
@@ -366,6 +370,14 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		B8C38DB027902E77008D8E66 /* Notifications */ = {
+			isa = PBXGroup;
+			children = (
+				B8C38DB127902EFB008D8E66 /* Notification+DataRequest.swift */,
+			);
+			path = Notifications;
+			sourceTree = "<group>";
+		};
 		B8E0237427676297003FBC9D /* Request */ = {
 			isa = PBXGroup;
 			children = (
@@ -490,6 +502,7 @@
 		OBJ_7 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				B8C38DB027902E77008D8E66 /* Notifications */,
 				B8E0237427676297003FBC9D /* Request */,
 				OBJ_8 /* Extensions */,
 				OBJ_15 /* HTTPRequest */,
@@ -525,6 +538,7 @@
 				B872BEC225A38C0D0031D619 /* HierarchicalDateFormatter.swift */,
 				B872BEAE25A38BA70031D619 /* HTTPHeader+Headers.swift */,
 				B8E023772767663C003FBC9D /* DispatchQueue+Extensions.swift */,
+				B8C38DB327902FA8008D8E66 /* NotificationCenter+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -695,11 +709,13 @@
 				OBJ_133 /* OSLog+Logger.swift in Sources */,
 				OBJ_134 /* String+Data.swift in Sources */,
 				OBJ_135 /* String+Extensions.swift in Sources */,
+				B8C38DB227902EFB008D8E66 /* Notification+DataRequest.swift in Sources */,
 				OBJ_137 /* Array+URLQueryItem.swift in Sources */,
 				OBJ_138 /* Configuration.swift in Sources */,
 				OBJ_139 /* HTTPRequest.swift in Sources */,
 				OBJ_140 /* HTTPRequestable.swift in Sources */,
 				OBJ_142 /* DateFormatter+ISO8601.swift in Sources */,
+				B8C38DB427902FA8008D8E66 /* NotificationCenter+Extensions.swift in Sources */,
 				B8E0237F2767A00D003FBC9D /* DataRequestResult+Model.swift in Sources */,
 				B8E0237D27679E54003FBC9D /* Data+Codable.swift in Sources */,
 				OBJ_144 /* Result+Extensions.swift in Sources */,

--- a/Sources/Extensions/NotificationCenter+Extensions.swift
+++ b/Sources/Extensions/NotificationCenter+Extensions.swift
@@ -1,0 +1,35 @@
+//
+//  NotificationCenter+Extensions.swift
+//  HTTPRequest
+//
+//  Created by Ben Shutt on 13/01/2022.
+//
+
+import Foundation
+
+public extension NotificationCenter {
+
+    /// Observe posted `Notification`s using `closure`
+    ///
+    /// - Parameters:
+    ///   - name: `Notification.Name`
+    ///   - object: `Any?`
+    ///   - queue: `OperationQueue?`
+    ///   - closure: Closure to execute when a notification is posted
+    ///
+    /// - Returns: `NSObjectProtocol`, discardable result as you do not need to unregister the observer
+    @discardableResult
+    func addObserverClosure(
+        forName name: Notification.Name,
+        object: Any? = nil,
+        queue: OperationQueue? = .main,
+        using closure: @escaping (Notification) -> Void
+    ) -> NSObjectProtocol {
+        return addObserver(
+            forName: name,
+            object: object,
+            queue: queue,
+            using: closure
+        )
+    }
+}

--- a/Sources/Notifications/Notification+DataRequest.swift
+++ b/Sources/Notifications/Notification+DataRequest.swift
@@ -1,0 +1,92 @@
+//
+//  Notification+DataRequest.swift
+//  HTTPRequest
+//
+//  Created by Ben Shutt on 13/01/2022.
+//
+
+import Foundation
+import Alamofire
+
+// MARK: - Notification.Name
+
+public extension Notification.Name {
+
+    /// `Name` of `Notification` posted when a `DataResponse` is received for a `DataRequest`
+    static let dataResponse = Notification.Name(
+        rawValue: "com.3sidedcube.\(HTTPRequest.self).\(DataResponse.self)"
+    )
+}
+
+// MARK: - String + UserInfo
+
+private extension String {
+
+    /// Key for `DataRequest` in `Notification` `userInfo`
+    static var dataRequestInfoKey: String {
+        return "\(Notification.Name.dataResponse.rawValue).\(DataRequest.self).key"
+    }
+
+    /// Key for `DataResponse` in `Notification` `userInfo`
+    static var dataResponseInfoKey: String {
+        return "\(Notification.Name.dataResponse.rawValue).key"
+    }
+}
+
+// MARK: - Notification
+
+private extension Notification {
+
+    /// `DataRequest` from `userInfo`
+    var dataRequest: DataRequest? {
+        return userInfo?[String.dataRequestInfoKey] as? DataRequest
+    }
+
+    /// `DataResponse` from `userInfo`
+    var dataResponse: DataResponse? {
+        return userInfo?[String.dataResponseInfoKey] as? DataResponse
+    }
+}
+
+// MARK: - NotificationCenter
+
+public extension NotificationCenter {
+
+    /// Post `dataRequest` and `dataResponse` on the `NotificationCenter`
+    ///
+    /// - Parameters:
+    ///   - dataRequest: `DataRequest`
+    ///   - dataResponse: `DataResponse`
+    ///   - object: `Any`
+    func post(dataRequest: DataRequest, dataResponse: DataResponse, object: Any) {
+        post(name: .dataResponse, object: object, userInfo: [
+            String.dataRequestInfoKey: dataRequest,
+            String.dataResponseInfoKey: dataResponse
+        ])
+    }
+
+    /// Add an observer closure invoked when a `DataResponse` is received after making a `DataRequest`
+    ///
+    /// - Parameters:
+    ///   - object: `Any?`
+    ///   - queue: `OperationQueue?`
+    ///   - closure: Closure invoked
+    ///
+    /// - Returns: `NSObjectProtocol`
+    @discardableResult
+    func addObserverForDataResponse(
+        object: Any? = nil,
+        queue: OperationQueue? = .main,
+        closure: @escaping (DataRequest, DataResponse) -> Void
+    ) -> NSObjectProtocol {
+        return addObserverClosure(
+            forName: .dataResponse,
+            object: object,
+            queue: queue
+        ) { sender in
+            guard let dataRequest = sender.dataRequest else { return }
+            guard let dataResponse = sender.dataResponse else { return }
+            closure(dataRequest, dataResponse)
+        }
+    }
+}

--- a/Sources/Request/DataRequest+Request.swift
+++ b/Sources/Request/DataRequest+Request.swift
@@ -33,6 +33,13 @@ public extension DataRequest {
 
             // Complete passing the response
             completion(response)
+
+            // Post DataResponse on NotificationCenter
+            NotificationCenter.default.post(
+                dataRequest: self,
+                dataResponse: response,
+                object: self
+            )
         }
     }
 }


### PR DESCRIPTION
### Summary
Post on the `NotificationCenter` when a `DataResponse` is received after making a `DataRequest`.

### Description
This allows clients, such as mobile apps, to respond to, say, 5XX errors and present/handle a server error.